### PR TITLE
Times are taken from the first exodus result

### DIFF
--- a/gui/OtterViewportsTab.py
+++ b/gui/OtterViewportsTab.py
@@ -77,7 +77,6 @@ class OtterViewportsTab(OtterObjectsTab):
 
     PARAMS_VPP_PLOT = [
         { 'name': 'csv-file', 'value': '', 'hint': 'The file name of the CSV file', 'req': True },
-        { 'name': 'exodus-file', 'value': '', 'hint': 'The file name of the Exodus II file', 'req': True },
         { 'name': 'variables', 'value': [], 'hint': 'The list of the variables', 'req': True },
         { 'name': 'legend', 'group': True, 'childs': PARAMS_LEGEND, 'hint': 'The legend' },
         { 'name': 'viewport', 'value': [0, 0, 1, 1], 'hint': 'The viewport', 'req': False },

--- a/otter/__init__.py
+++ b/otter/__init__.py
@@ -72,11 +72,10 @@ def movie(movie):
 
     MOVIE_MAP = {}
 
-    common.checkMandatoryArgs(['size', 'file', 'duration', 'times'], movie)
+    common.checkMandatoryArgs(['size', 'file', 'duration'], movie)
 
     if 'time-unit' in movie:
         common.setTimeUnit(movie['time-unit'])
-    common.times = movie.pop('times')
     common.t = 0
     common.timestep = None
 
@@ -101,6 +100,12 @@ def movie(movie):
         raise SystemExit("The 'frame' parameter needs to contain '*'.")
 
     items, results = _buildResults(movie)
+
+    # if 'times' are explicitly specified in the movie object, use those
+    if 'times' in movie:
+        common.times = movie.pop('times')
+    if common.times == None or len(common.times) == 0:
+        raise SystemExit("No times were specifed for rendering the movie.")
 
     args = common.remap(movie, MOVIE_MAP)
     args['chigger'] = True

--- a/otter/viewports.py
+++ b/otter/viewports.py
@@ -60,6 +60,9 @@ class ViewportExodusResult(Viewport):
             time = common.t,
             timestep = common.timestep)
 
+        if common.times == None:
+            common.times = self.exodus_reader.getTimes()
+
         args = common.remap(viewport, self.MAP)
         args['camera'] = self.camera
 
@@ -94,11 +97,7 @@ class ViewportVPPPlot(Viewport):
     def __init__(self, viewport):
         super(ViewportVPPPlot, self).__init__(viewport)
 
-        common.checkMandatoryArgs(['exodus-file', 'csv-file', 'variables', 'viewport'], viewport)
-
-        self.exodus_file = viewport.pop('exodus-file')
-        self.exodus_reader = chigger.exodus.ExodusReader(self.exodus_file, time = common.t, timestep = common.timestep)
-        self.times = self.exodus_reader.getTimes()
+        common.checkMandatoryArgs(['csv-file', 'variables', 'viewport'], viewport)
 
         self.csv_file = viewport.pop('csv-file')
         self.data = mooseutils.VectorPostprocessorReader(self.csv_file)
@@ -168,8 +167,8 @@ class ViewportVPPPlot(Viewport):
             line.setOptions(x = x, y = y)
 
     def _getTimeIndex(self, time):
-        n = len(self.times)
-        idx = bisect.bisect_right(self.times, time) - 1
+        n = len(common.times)
+        idx = bisect.bisect_right(common.times, time) - 1
         if idx < 0:
             idx = 0
         elif idx > n:


### PR DESCRIPTION
Times can be specified in the movie object and if so they are used, but
'times' are no longer a required parameter.