### PR TITLE
Code

### DIFF
--- a/otter/plugins/viz/BackgroundProps.py
+++ b/otter/plugins/viz/BackgroundProps.py
@@ -6,7 +6,7 @@ from otter.plugins.common.ColorPicker import ColorPicker
 from otter.plugins.common.ColorButton import ColorButton
 
 
-class RootProps(PropsBase):
+class BackgroundProps(PropsBase):
     """
     Properties page to display when root is selected
     """
@@ -14,6 +14,7 @@ class RootProps(PropsBase):
     def __init__(self, renderer, parent=None):
         super().__init__(parent)
         self._vtk_renderer = renderer
+        self.setWindowTitle("Background")
         self.setupWidgets()
         self.connectSignals()
 

--- a/otter/plugins/viz/FileProps.py
+++ b/otter/plugins/viz/FileProps.py
@@ -1,12 +1,15 @@
 import vtk
-from PyQt5 import QtWidgets, QtCore, QtGui
+from PyQt5.QtWidgets import QLineEdit, QComboBox, QLabel, QTreeView, \
+    QAbstractItemView
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor, QStandardItemModel, QStandardItem, QBrush
 from otter.plugins.viz.PropsBase import PropsBase
 from otter.plugins.common.Reader import Reader
 
 
 class FileProps(PropsBase):
     """
-    Properties page to display when root is selected
+    Properties page to display when file is selected
     """
 
     IDX_NAME = 0
@@ -19,13 +22,13 @@ class FileProps(PropsBase):
         self._block_actors = {}
 
         self._colors = [
-            QtGui.QColor(156, 207, 237),
-            QtGui.QColor(165, 165, 165),
-            QtGui.QColor(60, 97, 180),
-            QtGui.QColor(234, 234, 234),
-            QtGui.QColor(197, 226, 243),
-            QtGui.QColor(127, 127, 127),
-            QtGui.QColor(250, 182, 0)
+            QColor(156, 207, 237),
+            QColor(165, 165, 165),
+            QColor(60, 97, 180),
+            QColor(234, 234, 234),
+            QColor(197, 226, 243),
+            QColor(127, 127, 127),
+            QColor(250, 182, 0)
         ]
 
         self.setupWidgets()
@@ -35,7 +38,7 @@ class FileProps(PropsBase):
         return list(self._block_actors.values())
 
     def setupWidgets(self):
-        self._file_name = QtWidgets.QLineEdit(self._reader.getFileName())
+        self._file_name = QLineEdit(self._reader.getFileName())
         self._file_name.setReadOnly(True)
         self._layout.addWidget(self._file_name)
         self._setupVariableWidget()
@@ -47,47 +50,46 @@ class FileProps(PropsBase):
     def _setupVariableWidget(self):
         var_info = self._reader.getVariableInfo()
 
-        self._variable = QtWidgets.QComboBox()
+        self._variable = QComboBox()
         self._variable.addItem("Block colors", None)
         for vi in var_info:
             self._variable.addItem(vi.name, vi)
         self._layout.addWidget(self._variable)
 
     def _setupBlocksWidget(self):
-        self._lbl_blocks = QtWidgets.QLabel("Blocks")
+        self._lbl_blocks = QLabel("Blocks")
         self._layout.addWidget(self._lbl_blocks)
-        self._block_model = QtGui.QStandardItemModel()
+        self._block_model = QStandardItemModel()
         self._block_model.setHorizontalHeaderLabels([
             "Name", "", "ID"
         ])
         self._block_model.itemChanged.connect(self.onBlockChanged)
-        self._blocks = QtWidgets.QTreeView()
+        self._blocks = QTreeView()
         self._blocks.setFixedHeight(200)
         self._blocks.setRootIsDecorated(False)
         self._blocks.setModel(self._block_model)
-        self._blocks.setEditTriggers(
-            QtWidgets.QAbstractItemView.NoEditTriggers)
+        self._blocks.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self._blocks.setColumnWidth(0, 200)
         self._blocks.setColumnWidth(1, 20)
         self._blocks.setColumnWidth(2, 50)
         self._layout.addWidget(self._blocks)
 
     def _addBlock(self, row, binfo, clr_idx):
-        si_name = QtGui.QStandardItem()
+        si_name = QStandardItem()
         si_name.setText(binfo.name)
         si_name.setCheckable(True)
-        si_name.setCheckState(QtCore.Qt.Checked)
+        si_name.setCheckState(Qt.Checked)
         si_name.setData(binfo)
         self._block_model.setItem(row, self.IDX_NAME, si_name)
 
-        si_clr = QtGui.QStandardItem()
+        si_clr = QStandardItem()
         si_clr.setText('\u25a0')
         qcolor = self._colors[clr_idx]
-        si_clr.setForeground(QtGui.QBrush(qcolor))
+        si_clr.setForeground(QBrush(qcolor))
         si_clr.setData(clr_idx)
         self._block_model.setItem(row, self.IDX_COLOR, si_clr)
 
-        si_id = QtGui.QStandardItem()
+        si_id = QStandardItem()
         si_id.setText(str(binfo.number))
         self._block_model.setItem(row, self.IDX_ID, si_id)
 
@@ -141,7 +143,7 @@ class FileProps(PropsBase):
 
     def onBlockChanged(self, item):
         if item.column() == self.IDX_NAME:
-            visible = item.checkState() == QtCore.Qt.Checked
+            visible = item.checkState() == Qt.Checked
             binfo = item.data()
             actor = self._block_actors[binfo.number]
             actor.SetVisibility(visible)

--- a/otter/plugins/viz/FontPropertiesWidget.py
+++ b/otter/plugins/viz/FontPropertiesWidget.py
@@ -1,7 +1,8 @@
-from PyQt5 import QtWidgets, QtGui
+from PyQt5.QtWidgets import QWidget, QHBoxLayout, QComboBox, QPushButton
+from PyQt5.QtGui import QIntValidator
 
 
-class FontPropertiesWidget(QtWidgets.QWidget):
+class FontPropertiesWidget(QWidget):
     """
     Widget for setting font properties
     """
@@ -10,17 +11,17 @@ class FontPropertiesWidget(QtWidgets.QWidget):
         super().__init__(parent)
         self._vtk_property = None
 
-        self._layout = QtWidgets.QHBoxLayout()
+        self._layout = QHBoxLayout()
         self._layout.setContentsMargins(0, 0, 0, 0)
         self._layout.setSpacing(1)
 
-        self._font_family = QtWidgets.QComboBox()
+        self._font_family = QComboBox()
         self._font_family.addItem("Arial")
         self._font_family.addItem("Courier")
         self._font_family.addItem("Times")
         self._layout.addWidget(self._font_family)
 
-        self._font_size = QtWidgets.QComboBox()
+        self._font_size = QComboBox()
         self._font_size.addItem("9")
         self._font_size.addItem("10")
         self._font_size.addItem("11")
@@ -34,16 +35,16 @@ class FontPropertiesWidget(QtWidgets.QWidget):
         self._font_size.setFixedWidth(60)
         self._layout.addWidget(self._font_size)
 
-        validator = QtGui.QIntValidator()
+        validator = QIntValidator()
         validator.setBottom(1)
         self._font_size.setValidator(validator)
 
-        self._bold_button = QtWidgets.QPushButton("B")
+        self._bold_button = QPushButton("B")
         self._bold_button.setFixedSize(48, 32)
         self._bold_button.setCheckable(True)
         self._layout.addWidget(self._bold_button)
 
-        self._italics_button = QtWidgets.QPushButton("I")
+        self._italics_button = QPushButton("I")
         self._italics_button.setCheckable(True)
         self._italics_button.setFixedSize(48, 32)
         self._layout.addWidget(self._italics_button)

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -34,7 +34,7 @@ class LoadThread(QtCore.QThread):
         return self._reader
 
 
-class RenderWindow(PluginWindowBase):
+class MainWindow(PluginWindowBase):
     """
     Window for displaying the result
     """

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -208,6 +208,7 @@ class MainWindow(PluginWindowBase):
         if isinstance(actors, list):
             for act in actors:
                 self._vtk_renderer.AddViewProp(act)
+        self.resetCamera()
 
     def onClose(self):
         self.close()
@@ -265,3 +266,10 @@ class MainWindow(PluginWindowBase):
         else:
             self._params_window.show()
         self.updateMenuBar()
+
+    def resetCamera(self):
+        camera = self._vtk_renderer.GetActiveCamera()
+        focal_point = camera.GetFocalPoint()
+        camera.SetPosition(focal_point[0], focal_point[1], 1)
+        camera.SetRoll(0)
+        self._vtk_renderer.ResetCamera()

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -10,6 +10,7 @@ from otter.plugins.common.OtterInteractorStyle3D import OtterInteractorStyle3D
 from otter.plugins.common.OtterInteractorStyle2D import OtterInteractorStyle2D
 from otter.plugins.PluginWindowBase import PluginWindowBase
 from otter.plugins.viz.ParamsWindow import ParamsWindow
+from otter.plugins.viz.BackgroundProps import BackgroundProps
 from otter.plugins.viz.FileProps import FileProps
 from otter.plugins.viz.TextProps import TextProps
 
@@ -82,6 +83,8 @@ class MainWindow(PluginWindowBase):
         self.setCentralWidget(self._vtk_widget)
 
         self._params_window = ParamsWindow(self)
+
+        self._bkgnd_props = BackgroundProps(self._vtk_renderer, self)
 
     def setupMenuBar(self):
         file_menu = self._menubar.addMenu("File")
@@ -165,6 +168,7 @@ class MainWindow(PluginWindowBase):
     def clear(self):
         # todo: remove actors and free them prop dialogs
         self._params_window.clear()
+        self._params_window.addPipelineItem(self._bkgnd_props)
 
     def onUpdateWindow(self):
         self._vtk_render_window.Render()

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -168,7 +168,7 @@ class MainWindow(PluginWindowBase):
         super().closeEvent(event)
 
     def clear(self):
-        # todo: remove actors and free them prop dialogs
+        self._vtk_renderer.RemoveAllViewProps()
         self._params_window.clear()
         self._params_window.addPipelineItem(self._bkgnd_props)
 

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -1,7 +1,9 @@
 import os
 import vtk
 from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
-from PyQt5 import QtWidgets, QtCore
+from PyQt5.QtWidgets import QToolBar, QProgressDialog, QMessageBox, \
+    QFileDialog
+from PyQt5.QtCore import QThread, QTimer, Qt
 from otter.plugins.common.LoadFileEvent import LoadFileEvent
 from otter.plugins.common.ExodusIIReader import ExodusIIReader
 from otter.plugins.common.VTKReader import VTKReader
@@ -15,7 +17,7 @@ from otter.plugins.viz.FileProps import FileProps
 from otter.plugins.viz.TextProps import TextProps
 
 
-class LoadThread(QtCore.QThread):
+class LoadThread(QThread):
     """ Worker thread for loading data set files """
 
     def __init__(self, file_name):
@@ -73,7 +75,7 @@ class MainWindow(PluginWindowBase):
         self.show()
         self.updateMenuBar()
 
-        self._update_timer = QtCore.QTimer()
+        self._update_timer = QTimer()
         self._update_timer.timeout.connect(self.onUpdateWindow)
         self._update_timer.start(250)
 
@@ -110,7 +112,7 @@ class MainWindow(PluginWindowBase):
         self._view_objects_action.setChecked(self._params_window.isVisible())
 
     def setupToolBar(self):
-        self._toolbar = QtWidgets.QToolBar()
+        self._toolbar = QToolBar()
         self._toolbar.setMovable(False)
         self._toolbar.setFloatable(False)
         self._toolbar.setFixedHeight(32)
@@ -144,7 +146,7 @@ class MainWindow(PluginWindowBase):
 
     def dropEvent(self, event):
         if event.mimeData().hasUrls():
-            event.setDropAction(QtCore.Qt.CopyAction)
+            event.setDropAction(Qt.CopyAction)
             event.accept()
 
             file_names = []
@@ -176,18 +178,18 @@ class MainWindow(PluginWindowBase):
     def loadFile(self, file_name):
         self._load_thread = LoadThread(file_name)
         if self._load_thread.getReader() is not None:
-            self._progress = QtWidgets.QProgressDialog(
+            self._progress = QProgressDialog(
                 "Loading {}...".format(os.path.basename(file_name)),
                 None, 0, 0, self)
-            self._progress.setWindowModality(QtCore.Qt.WindowModal)
+            self._progress.setWindowModality(Qt.WindowModal)
             self._progress.setMinimumDuration(0)
             self._progress.show()
 
             self._load_thread.finished.connect(self.onFileLoadFinished)
-            self._load_thread.start(QtCore.QThread.IdlePriority)
+            self._load_thread.start(QThread.IdlePriority)
         else:
             self._load_thread = None
-            QtWidgets.QMessageBox.critical(
+            QMessageBox.critical(
                 None,
                 "Unsupported file format",
                 "Selected file in not in a supported format.\n"
@@ -229,7 +231,7 @@ class MainWindow(PluginWindowBase):
         self.clear()
 
     def onOpenFile(self):
-        file_name, f = QtWidgets.QFileDialog.getOpenFileName(
+        file_name, f = QFileDialog.getOpenFileName(
             self,
             'Open File',
             "",
@@ -253,7 +255,7 @@ class MainWindow(PluginWindowBase):
             self._vtk_renderer.AddViewProp(actor)
 
     def onAddFile(self):
-        file_name, f = QtWidgets.QFileDialog.getOpenFileName(
+        file_name, f = QFileDialog.getOpenFileName(
             self,
             'Open File',
             "",

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -223,7 +223,7 @@ class MainWindow(PluginWindowBase):
         self.clear()
 
     def onOpenFile(self):
-        file_name, f = QFileDialog.getOpenFileName(
+        file_name, _ = QFileDialog.getOpenFileName(
             self,
             'Open File',
             "",

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -6,6 +6,8 @@ from otter.plugins.common.LoadFileEvent import LoadFileEvent
 from otter.plugins.common.ExodusIIReader import ExodusIIReader
 from otter.plugins.common.VTKReader import VTKReader
 from otter.plugins.common.PetscHDF5Reader import PetscHDF5Reader
+from otter.plugins.common.OtterInteractorStyle3D import OtterInteractorStyle3D
+from otter.plugins.common.OtterInteractorStyle2D import OtterInteractorStyle2D
 from otter.plugins.PluginWindowBase import PluginWindowBase
 from otter.plugins.viz.ParamsWindow import ParamsWindow
 from otter.plugins.viz.FileProps import FileProps
@@ -194,6 +196,12 @@ class MainWindow(PluginWindowBase):
         self._progress.hide()
         self._progress = None
 
+        if reader.getDimensionality() == 3:
+            style = OtterInteractorStyle3D(self)
+        else:
+            style = OtterInteractorStyle2D(self)
+        self._vtk_interactor.SetInteractorStyle(style)
+
         file_name = reader.getFileName()
         self.addToRecentFiles(file_name)
         self._file_name = file_name
@@ -273,3 +281,6 @@ class MainWindow(PluginWindowBase):
         camera.SetPosition(focal_point[0], focal_point[1], 1)
         camera.SetRoll(0)
         self._vtk_renderer.ResetCamera()
+
+    def onClicked(self, pt):
+        pass

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -79,7 +79,6 @@ class MainWindow(PluginWindowBase):
         self.setCentralWidget(self._vtk_widget)
 
         self._params_window = ParamsWindow(self)
-        self._params_window.hide()
 
     def setupMenuBar(self):
         file_menu = self._menubar.addMenu("File")
@@ -118,6 +117,10 @@ class MainWindow(PluginWindowBase):
 
     def _updateViewModeLocation(self):
         pass
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self.updateParamsWindowGeometry()
 
     def dragEnterEvent(self, event):
         if event.mimeData().hasUrls():
@@ -237,3 +240,12 @@ class MainWindow(PluginWindowBase):
             "VTK Unstructured Grid files (*.vtk)")
         if file_name:
             self.loadFile(file_name)
+
+    def updateParamsWindowGeometry(self):
+        self._params_window.adjustSize()
+        margin = 10
+        height = self.geometry().height() - (2 * margin)
+        left = margin
+        top = margin
+        self._params_window.setGeometry(
+            left, top, self._params_window.width(), height)

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -257,6 +257,11 @@ class MainWindow(PluginWindowBase):
         if file_name:
             self.loadFile(file_name)
 
+    def remove(self, props):
+        actor = props.getVtkActor()
+        if actor is not None:
+            self._vtk_renderer.RemoveViewProp(actor)
+
     def updateToolBarGeometry(self):
         self._toolbar.adjustSize()
         margin = 10

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -1,8 +1,7 @@
 import os
 import vtk
 from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
-from PyQt5.QtWidgets import QToolBar, QProgressDialog, QMessageBox, \
-    QFileDialog
+from PyQt5.QtWidgets import QProgressDialog, QMessageBox, QFileDialog
 from PyQt5.QtCore import QThread, QTimer, Qt
 from otter.plugins.common.LoadFileEvent import LoadFileEvent
 from otter.plugins.common.ExodusIIReader import ExodusIIReader
@@ -12,6 +11,7 @@ from otter.plugins.common.OtterInteractorStyle3D import OtterInteractorStyle3D
 from otter.plugins.common.OtterInteractorStyle2D import OtterInteractorStyle2D
 from otter.plugins.PluginWindowBase import PluginWindowBase
 from otter.plugins.viz.ParamsWindow import ParamsWindow
+from otter.plugins.viz.ToolBar import ToolBar
 from otter.plugins.viz.BackgroundProps import BackgroundProps
 from otter.plugins.viz.FileProps import FileProps
 from otter.plugins.viz.TextProps import TextProps
@@ -112,16 +112,7 @@ class MainWindow(PluginWindowBase):
         self._view_objects_action.setChecked(self._params_window.isVisible())
 
     def setupToolBar(self):
-        self._toolbar = QToolBar()
-        self._toolbar.setMovable(False)
-        self._toolbar.setFloatable(False)
-        self._toolbar.setFixedHeight(32)
-        self._toolbar.setStyleSheet("""
-            border: none;
-            """)
-        self._toolbar.addAction("O", self.onOpenFile)
-        self._toolbar.addSeparator()
-        self._toolbar.addAction("T", self.onAddText)
+        self._toolbar = ToolBar(self)
 
     def updateWindowTitle(self):
         title = "Viz"
@@ -136,6 +127,7 @@ class MainWindow(PluginWindowBase):
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
+        self.updateToolBarGeometry()
         self.updateParamsWindowGeometry()
 
     def dragEnterEvent(self, event):
@@ -265,12 +257,23 @@ class MainWindow(PluginWindowBase):
         if file_name:
             self.loadFile(file_name)
 
-    def updateParamsWindowGeometry(self):
-        self._params_window.adjustSize()
+    def updateToolBarGeometry(self):
+        self._toolbar.adjustSize()
         margin = 10
-        height = self.geometry().height() - (2 * margin)
+        width = self.geometry().width() - (2 * margin)
+        height = 32
         left = margin
         top = margin
+        self._toolbar.setGeometry(left, top, width, height)
+
+    def updateParamsWindowGeometry(self):
+        toolbar_geom = self._toolbar.geometry()
+
+        self._params_window.adjustSize()
+        margin = 10
+        top = margin + toolbar_geom.height() + (margin / 2)
+        height = self.geometry().height() - top - margin
+        left = margin
         self._params_window.setGeometry(
             left, top, self._params_window.width(), height)
 

--- a/otter/plugins/viz/MainWindow.py
+++ b/otter/plugins/viz/MainWindow.py
@@ -68,6 +68,7 @@ class MainWindow(PluginWindowBase):
 
         self.clear()
         self.show()
+        self.updateMenuBar()
 
         self._update_timer = QtCore.QTimer()
         self._update_timer.timeout.connect(self.onUpdateWindow)
@@ -94,6 +95,14 @@ class MainWindow(PluginWindowBase):
         file_menu.addSeparator()
         self._render_action = file_menu.addAction(
             "Render", self.onRender, "Ctrl+Shift+R")
+
+        view_menu = self._menubar.addMenu("View")
+        self._view_objects_action = view_menu.addAction(
+            "Objects", self.onViewObjects)
+        self._view_objects_action.setCheckable(True)
+
+    def updateMenuBar(self):
+        self._view_objects_action.setChecked(self._params_window.isVisible())
 
     def setupToolBar(self):
         self._toolbar = QtWidgets.QToolBar()
@@ -249,3 +258,10 @@ class MainWindow(PluginWindowBase):
         top = margin
         self._params_window.setGeometry(
             left, top, self._params_window.width(), height)
+
+    def onViewObjects(self):
+        if self._params_window.isVisible():
+            self._params_window.hide()
+        else:
+            self._params_window.show()
+        self.updateMenuBar()

--- a/otter/plugins/viz/ParamsWindow.py
+++ b/otter/plugins/viz/ParamsWindow.py
@@ -1,5 +1,6 @@
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QSplitter, QTreeView, \
-    QAbstractItemView, QMenu
+    QAbstractItemView, QMenu, QGraphicsOpacityEffect, QHBoxLayout, QLabel, \
+    QSizePolicy, QPushButton
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtCore import Qt, QItemSelectionModel
 from otter.OTreeView import OTreeView
@@ -19,26 +20,65 @@ class ParamsWindow(QWidget):
         # TOOD: move to MainWindow
         self._root_props = RootProps(self._vtk_renderer, parent)
 
-        self.setAcceptDrops(True)
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setObjectName("options")
+        self.setStyleSheet("""
+            #options, #closeButton {
+                border-radius: 6px;
+                background-color: rgb(0, 0, 0);
+                color: #fff;
+            }
+            QLabel, QCheckBox {
+                background-color: rgb(0, 0, 0);
+                color: #fff;
+            }
+            """)
 
         self.setupWidgets()
-        self.setMinimumWidth(220)
 
-        self.show()
+        effect = QGraphicsOpacityEffect()
+        effect.setOpacity(0.66)
+        self.setGraphicsEffect(effect)
+
+        self.setMinimumWidth(220)
+        self.updateWidgets()
+        self.connectSignals()
+
+        self.setAcceptDrops(True)
 
     def mainWnd(self):
         return self._main_wnd
 
     def setupWidgets(self):
         layout = QVBoxLayout()
-        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setContentsMargins(12, 6, 12, 12)
         layout.setSpacing(0)
+
+        title_layout = QHBoxLayout()
+        self.title = QLabel("Objects")
+        self.title.setStyleSheet("""
+            font-weight: bold;
+            qproperty-alignment: AlignLeft;
+            """)
+        self.title.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        title_layout.addWidget(self.title)
+
+        self.close_button = QPushButton("\u2716")
+        self.close_button.setObjectName("closeButton")
+        self.close_button.setStyleSheet("""
+            font-size: 20px;
+            """)
+        title_layout.addWidget(self.close_button)
+
+        layout.addLayout(title_layout)
+
+        layout.addSpacing(4)
 
         self._splitter = QSplitter(Qt.Vertical)
         self._splitter.setHandleWidth(4)
 
         self._pipeline_model = QStandardItemModel()
-        self._pipeline = QTreeView()
+        self._pipeline = OTreeView()
         self._pipeline.setRootIsDecorated(False)
         self._pipeline.setHeaderHidden(True)
         self._pipeline.setModel(self._pipeline_model)
@@ -54,7 +94,7 @@ class ParamsWindow(QWidget):
         self._splitter.addWidget(self._blocks)
 
         self._root = QStandardItem()
-        self._root.setText("Pipeline")
+        self._root.setText("Background")
         self._root.setData(self._root_props)
         self._pipeline_model.setItem(0, 0, self._root)
 
@@ -62,11 +102,15 @@ class ParamsWindow(QWidget):
 
         self.setLayout(layout)
 
+    def connectSignals(self):
         self._pipeline.doubleClicked.connect(self.onPipelineDoubleClicked)
         self._pipeline.customContextMenuRequested.connect(
             self.onPipelineCustomContextMenu)
         self._pipeline_model.itemChanged.connect(
             self.onPipelineItemChanged)
+
+    def updateWidgets(self):
+        pass
 
     def dragEnterEvent(self, event):
         if event.mimeData().hasUrls():

--- a/otter/plugins/viz/ParamsWindow.py
+++ b/otter/plugins/viz/ParamsWindow.py
@@ -54,20 +54,20 @@ class ParamsWindow(QWidget):
         layout.setSpacing(4)
 
         title_layout = QHBoxLayout()
-        self.title = QLabel("Objects")
-        self.title.setStyleSheet("""
+        self._title = QLabel("Objects")
+        self._title.setStyleSheet("""
             font-weight: bold;
             qproperty-alignment: AlignLeft;
             """)
-        self.title.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
-        title_layout.addWidget(self.title)
+        self._title.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        title_layout.addWidget(self._title)
 
-        self.close_button = QPushButton("\u2716")
-        self.close_button.setObjectName("closeButton")
-        self.close_button.setStyleSheet("""
+        self._close_button = QPushButton("\u2716")
+        self._close_button.setObjectName("closeButton")
+        self._close_button.setStyleSheet("""
             font-size: 20px;
             """)
-        title_layout.addWidget(self.close_button)
+        title_layout.addWidget(self._close_button)
 
         layout.addLayout(title_layout)
 
@@ -101,6 +101,7 @@ class ParamsWindow(QWidget):
         self._pipeline.customContextMenuRequested.connect(
             self.onPipelineCustomContextMenu)
         self._pipeline_model.itemChanged.connect(self.onPipelineItemChanged)
+        self._close_button.clicked.connect(self.hide)
 
     def updateWidgets(self):
         pass
@@ -187,3 +188,7 @@ class ParamsWindow(QWidget):
         name = item.text()
         props = item.data()
         props.setWindowTitle(name)
+
+    def hide(self):
+        super().hide()
+        self._main_wnd.updateMenuBar()

--- a/otter/plugins/viz/ParamsWindow.py
+++ b/otter/plugins/viz/ParamsWindow.py
@@ -13,7 +13,7 @@ class ParamsWindow(QtWidgets.QWidget):
         self._main_wnd = parent
         self._vtk_renderer = parent._vtk_renderer
 
-        # TOOD: move to RenderWindow
+        # TOOD: move to MainWindow
         self._root_props = RootProps(self._vtk_renderer, parent)
 
         self.setAcceptDrops(True)

--- a/otter/plugins/viz/ParamsWindow.py
+++ b/otter/plugins/viz/ParamsWindow.py
@@ -1,9 +1,12 @@
-from PyQt5 import QtWidgets, QtCore, QtGui
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QSplitter, QTreeView, \
+    QAbstractItemView, QMenu
+from PyQt5.QtGui import QStandardItemModel, QStandardItem
+from PyQt5.QtCore import Qt, QItemSelectionModel
 from otter.OTreeView import OTreeView
 from otter.plugins.viz.RootProps import RootProps
 
 
-class ParamsWindow(QtWidgets.QWidget):
+class ParamsWindow(QWidget):
     """
     Window for entering parameters
     """
@@ -27,32 +30,30 @@ class ParamsWindow(QtWidgets.QWidget):
         return self._main_wnd
 
     def setupWidgets(self):
-        layout = QtWidgets.QVBoxLayout()
+        layout = QVBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
         layout.setSpacing(0)
 
-        self._splitter = QtWidgets.QSplitter(QtCore.Qt.Vertical)
+        self._splitter = QSplitter(Qt.Vertical)
         self._splitter.setHandleWidth(4)
 
-        self._pipeline_model = QtGui.QStandardItemModel()
-        self._pipeline = QtWidgets.QTreeView()
+        self._pipeline_model = QStandardItemModel()
+        self._pipeline = QTreeView()
         self._pipeline.setRootIsDecorated(False)
         self._pipeline.setHeaderHidden(True)
         self._pipeline.setModel(self._pipeline_model)
         # self._pipeline.setItemsExpandable(False)
         self._pipeline.setRootIsDecorated(True)
         self._pipeline.setExpandsOnDoubleClick(False)
-        self._pipeline.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)
-        self._pipeline.setSelectionMode(
-            QtWidgets.QAbstractItemView.SingleSelection)
-        self._pipeline.setEditTriggers(
-            QtWidgets.QAbstractItemView.NoEditTriggers)
+        self._pipeline.setContextMenuPolicy(Qt.CustomContextMenu)
+        self._pipeline.setSelectionMode(QAbstractItemView.SingleSelection)
+        self._pipeline.setEditTriggers(QAbstractItemView.NoEditTriggers)
         self._splitter.addWidget(self._pipeline)
 
         self._blocks = OTreeView()
         self._splitter.addWidget(self._blocks)
 
-        self._root = QtGui.QStandardItem()
+        self._root = QStandardItem()
         self._root.setText("Pipeline")
         self._root.setData(self._root_props)
         self._pipeline_model.setItem(0, 0, self._root)
@@ -75,7 +76,7 @@ class ParamsWindow(QtWidgets.QWidget):
 
     def dropEvent(self, event):
         if event.mimeData().hasUrls():
-            event.setDropAction(QtCore.Qt.CopyAction)
+            event.setDropAction(Qt.CopyAction)
             event.accept()
 
             file_names = []
@@ -94,7 +95,7 @@ class ParamsWindow(QtWidgets.QWidget):
     def addPipelineItem(self, props):
         name = props.windowTitle()
         rows = self._root.rowCount()
-        si = QtGui.QStandardItem()
+        si = QStandardItem()
         si.setText(name)
         si.setData(props)
         si.setEditable(True)
@@ -103,13 +104,13 @@ class ParamsWindow(QtWidgets.QWidget):
         index = self._pipeline_model.indexFromItem(si)
         sel_model = self._pipeline.selectionModel()
         sel_model.clearSelection()
-        sel_model.setCurrentIndex(index, QtCore.QItemSelectionModel.Select)
+        sel_model.setCurrentIndex(index, QItemSelectionModel.Select)
 
     def clear(self):
         self._root.removeRows(0, self._root.rowCount())
 
     def _onPipelineContextMenu(self, point):
-        menu = QtWidgets.QMenu()
+        menu = QMenu()
         menu.addAction("Rename", self.onRename)
         menu.addSeparator()
         menu.addAction("Edit...", self.onEdit)

--- a/otter/plugins/viz/ParamsWindow.py
+++ b/otter/plugins/viz/ParamsWindow.py
@@ -1,6 +1,5 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout, QSplitter, QTreeView, \
-    QAbstractItemView, QMenu, QGraphicsOpacityEffect, QHBoxLayout, QLabel, \
-    QSizePolicy, QPushButton
+from PyQt5.QtWidgets import QWidget, QVBoxLayout, QAbstractItemView, QMenu, \
+    QGraphicsOpacityEffect, QHBoxLayout, QLabel, QSizePolicy, QPushButton
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtCore import Qt, QItemSelectionModel
 from otter.OTreeView import OTreeView
@@ -52,7 +51,7 @@ class ParamsWindow(QWidget):
     def setupWidgets(self):
         layout = QVBoxLayout()
         layout.setContentsMargins(12, 6, 12, 12)
-        layout.setSpacing(0)
+        layout.setSpacing(4)
 
         title_layout = QHBoxLayout()
         self.title = QLabel("Objects")
@@ -74,9 +73,6 @@ class ParamsWindow(QWidget):
 
         layout.addSpacing(4)
 
-        self._splitter = QSplitter(Qt.Vertical)
-        self._splitter.setHandleWidth(4)
-
         self._pipeline_model = QStandardItemModel()
         self._pipeline = OTreeView()
         self._pipeline.setRootIsDecorated(False)
@@ -88,17 +84,15 @@ class ParamsWindow(QWidget):
         self._pipeline.setContextMenuPolicy(Qt.CustomContextMenu)
         self._pipeline.setSelectionMode(QAbstractItemView.SingleSelection)
         self._pipeline.setEditTriggers(QAbstractItemView.NoEditTriggers)
-        self._splitter.addWidget(self._pipeline)
+        layout.addWidget(self._pipeline)
 
         self._blocks = OTreeView()
-        self._splitter.addWidget(self._blocks)
+        layout.addWidget(self._blocks)
 
         self._root = QStandardItem()
         self._root.setText("Background")
         self._root.setData(self._root_props)
         self._pipeline_model.setItem(0, 0, self._root)
-
-        layout.addWidget(self._splitter)
 
         self.setLayout(layout)
 
@@ -106,8 +100,7 @@ class ParamsWindow(QWidget):
         self._pipeline.doubleClicked.connect(self.onPipelineDoubleClicked)
         self._pipeline.customContextMenuRequested.connect(
             self.onPipelineCustomContextMenu)
-        self._pipeline_model.itemChanged.connect(
-            self.onPipelineItemChanged)
+        self._pipeline_model.itemChanged.connect(self.onPipelineItemChanged)
 
     def updateWidgets(self):
         pass

--- a/otter/plugins/viz/ParamsWindow.py
+++ b/otter/plugins/viz/ParamsWindow.py
@@ -172,7 +172,13 @@ class ParamsWindow(QWidget):
             props.show()
 
     def onDelete(self):
-        pass
+        indexes = self._getSelectedPipelineItems()
+        if len(indexes) > 0:
+            index = indexes[0]
+            item = self._pipeline_model.itemFromIndex(index)
+            props = item.data()
+            self._main_wnd.remove(props)
+            self._pipeline_model.removeRow(index.row())
 
     def onPipelineItemChanged(self, item):
         name = item.text()

--- a/otter/plugins/viz/ParamsWindow.py
+++ b/otter/plugins/viz/ParamsWindow.py
@@ -3,7 +3,6 @@ from PyQt5.QtWidgets import QWidget, QVBoxLayout, QAbstractItemView, QMenu, \
 from PyQt5.QtGui import QStandardItemModel, QStandardItem
 from PyQt5.QtCore import Qt, QItemSelectionModel
 from otter.OTreeView import OTreeView
-from otter.plugins.viz.RootProps import RootProps
 
 
 class ParamsWindow(QWidget):
@@ -14,10 +13,6 @@ class ParamsWindow(QWidget):
     def __init__(self, parent):
         super().__init__(parent)
         self._main_wnd = parent
-        self._vtk_renderer = parent._vtk_renderer
-
-        # TOOD: move to MainWindow
-        self._root_props = RootProps(self._vtk_renderer, parent)
 
         self.setAttribute(Qt.WA_StyledBackground, True)
         self.setObjectName("options")
@@ -89,11 +84,6 @@ class ParamsWindow(QWidget):
         self._blocks = OTreeView()
         layout.addWidget(self._blocks)
 
-        self._root = QStandardItem()
-        self._root.setText("Background")
-        self._root.setData(self._root_props)
-        self._pipeline_model.setItem(0, 0, self._root)
-
         self.setLayout(layout)
 
     def connectSignals(self):
@@ -132,12 +122,12 @@ class ParamsWindow(QWidget):
 
     def addPipelineItem(self, props):
         name = props.windowTitle()
-        rows = self._root.rowCount()
+        rows = self._pipeline_model.rowCount()
         si = QStandardItem()
         si.setText(name)
         si.setData(props)
         si.setEditable(True)
-        self._root.insertRow(rows, si)
+        self._pipeline_model.insertRow(rows, si)
 
         index = self._pipeline_model.indexFromItem(si)
         sel_model = self._pipeline.selectionModel()
@@ -145,7 +135,7 @@ class ParamsWindow(QWidget):
         sel_model.setCurrentIndex(index, QItemSelectionModel.Select)
 
     def clear(self):
-        self._root.removeRows(0, self._root.rowCount())
+        self._pipeline_model.removeRows(0, self._pipeline_model.rowCount())
 
     def _onPipelineContextMenu(self, point):
         menu = QMenu()

--- a/otter/plugins/viz/PropsBase.py
+++ b/otter/plugins/viz/PropsBase.py
@@ -30,9 +30,8 @@ class PropsBase(QWidget):
 
     def show(self):
         render_wnd = self.parentWidget()
-        geom = render_wnd.geometry()
-        pt = QPoint(geom.left() + 1, geom.top() + 1)
+        geom = render_wnd._params_window.geometry()
+        pt = QPoint(geom.right() + 8, geom.top() + 1)
         pt = render_wnd.mapToGlobal(pt)
-        # TODO factor in the toolbar heigh programatically
-        self.move(pt.x(), pt.y() + 32)
+        self.move(pt.x(), pt.y())
         super().show()

--- a/otter/plugins/viz/PropsBase.py
+++ b/otter/plugins/viz/PropsBase.py
@@ -1,7 +1,8 @@
-from PyQt5 import QtWidgets, QtCore
+from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from PyQt5.QtCore import Qt, QPoint
 
 
-class PropsBase(QtWidgets.QWidget):
+class PropsBase(QWidget):
     """
     Base class for properties pages
     """
@@ -10,15 +11,15 @@ class PropsBase(QtWidgets.QWidget):
         super().__init__(parent)
         self._actor = None
 
-        self._layout = QtWidgets.QVBoxLayout()
+        self._layout = QVBoxLayout()
         self._layout.setContentsMargins(6, 6, 6, 6)
         self._layout.setSpacing(2)
         self.setLayout(self._layout)
 
-        self.setWindowFlag(QtCore.Qt.Tool)
-        self.setWindowFlag(QtCore.Qt.CustomizeWindowHint)
-        self.setWindowFlag(QtCore.Qt.WindowMinMaxButtonsHint, False)
-        self.setWindowFlag(QtCore.Qt.WindowFullscreenButtonHint, False)
+        self.setWindowFlag(Qt.Tool)
+        self.setWindowFlag(Qt.CustomizeWindowHint)
+        self.setWindowFlag(Qt.WindowMinMaxButtonsHint, False)
+        self.setWindowFlag(Qt.WindowFullscreenButtonHint, False)
 
     def buildVtkActor(self):
         return self._actor
@@ -30,7 +31,7 @@ class PropsBase(QtWidgets.QWidget):
     def show(self):
         render_wnd = self.parentWidget()
         geom = render_wnd.geometry()
-        pt = QtCore.QPoint(geom.left() + 1, geom.top() + 1)
+        pt = QPoint(geom.left() + 1, geom.top() + 1)
         pt = render_wnd.mapToGlobal(pt)
         # TODO factor in the toolbar heigh programatically
         self.move(pt.x(), pt.y() + 32)

--- a/otter/plugins/viz/PropsBase.py
+++ b/otter/plugins/viz/PropsBase.py
@@ -1,8 +1,8 @@
-from PyQt5.QtWidgets import QWidget, QVBoxLayout
+from PyQt5.QtWidgets import QVBoxLayout, QDialog
 from PyQt5.QtCore import Qt, QPoint
 
 
-class PropsBase(QWidget):
+class PropsBase(QDialog):
     """
     Base class for properties pages
     """
@@ -23,10 +23,6 @@ class PropsBase(QWidget):
 
     def buildVtkActor(self):
         return self._actor
-
-    def closeEvent(self, event):
-        self.hide()
-        event.ignore()
 
     def show(self):
         render_wnd = self.parentWidget()

--- a/otter/plugins/viz/PropsBase.py
+++ b/otter/plugins/viz/PropsBase.py
@@ -28,11 +28,10 @@ class PropsBase(QtWidgets.QWidget):
         event.ignore()
 
     def show(self):
-        parent = self.parentWidget()
-        render_wnd = parent._splitter.widget(1)
+        render_wnd = self.parentWidget()
         geom = render_wnd.geometry()
         pt = QtCore.QPoint(geom.left() + 1, geom.top() + 1)
-        pt = parent.mapToGlobal(pt)
+        pt = render_wnd.mapToGlobal(pt)
         # TODO factor in the toolbar heigh programatically
         self.move(pt.x(), pt.y() + 32)
         super().show()

--- a/otter/plugins/viz/RootProps.py
+++ b/otter/plugins/viz/RootProps.py
@@ -15,6 +15,7 @@ class RootProps(PropsBase):
         super().__init__(parent)
         self._vtk_renderer = renderer
         self.setupWidgets()
+        self.connectSignals()
 
     def setupWidgets(self):
         self._gradient_bkgnd = QCheckBox("Gradient background")
@@ -57,13 +58,14 @@ class RootProps(PropsBase):
 
         self._layout.addLayout(layout)
 
+        self.setLayout(self._layout)
+
+    def connectSignals(self):
         self._gradient_bkgnd.stateChanged.connect(self.onGradientBkgndChanged)
         self._color_btn.clicked.connect(self.onColorClicked)
         self._color_picker.colorChanged.connect(self.onColorChanged)
         self._color_2_btn.clicked.connect(self.onColor2Clicked)
         self._color_2_picker.colorChanged.connect(self.onColor2Changed)
-
-        self._layout.addStretch()
 
         self.onGradientBkgndChanged(self._gradient_bkgnd.checkState())
 

--- a/otter/plugins/viz/RootProps.py
+++ b/otter/plugins/viz/RootProps.py
@@ -1,4 +1,6 @@
-from PyQt5 import QtWidgets, QtCore, QtGui
+from PyQt5.QtWidgets import QCheckBox, QSizePolicy, QHBoxLayout, QLabel
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QColor
 from otter.plugins.viz.PropsBase import PropsBase
 from otter.plugins.common.ColorPicker import ColorPicker
 from otter.plugins.common.ColorButton import ColorButton
@@ -15,18 +17,16 @@ class RootProps(PropsBase):
         self.setupWidgets()
 
     def setupWidgets(self):
-        self._gradient_bkgnd = QtWidgets.QCheckBox("Gradient background")
+        self._gradient_bkgnd = QCheckBox("Gradient background")
         self._gradient_bkgnd.setSizePolicy(
-            QtWidgets.QSizePolicy.Expanding,
-            QtWidgets.QSizePolicy.Fixed
-        )
+            QSizePolicy.Expanding, QSizePolicy.Fixed)
         self._vtk_renderer.SetGradientBackground(False)
         self._layout.addWidget(self._gradient_bkgnd)
 
-        layout = QtWidgets.QHBoxLayout()
+        layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
 
-        lbl = QtWidgets.QLabel("Color")
+        lbl = QLabel("Color")
         layout.addWidget(lbl)
 
         self._color_picker = ColorPicker(self)
@@ -34,16 +34,16 @@ class RootProps(PropsBase):
         self._color_btn = ColorButton()
         qcolor = [0.321, 0.3411, 0.4313]
         self._color_btn.setColor(
-            QtGui.QColor.fromRgbF(qcolor[0], qcolor[1], qcolor[2]))
+            QColor.fromRgbF(qcolor[0], qcolor[1], qcolor[2]))
         self._vtk_renderer.SetBackground(qcolor)
         layout.addWidget(self._color_btn)
 
         self._layout.addLayout(layout)
 
-        layout = QtWidgets.QHBoxLayout()
+        layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
 
-        lbl = QtWidgets.QLabel("Color 2")
+        lbl = QLabel("Color 2")
         layout.addWidget(lbl)
 
         self._color_2_picker = ColorPicker(self)
@@ -51,7 +51,7 @@ class RootProps(PropsBase):
         self._color_2_btn = ColorButton()
         qcolor = [0.321, 0.3411, 0.4313]
         self._color_2_btn.setColor(
-            QtGui.QColor.fromRgbF(qcolor[0], qcolor[1], qcolor[2]))
+            QColor.fromRgbF(qcolor[0], qcolor[1], qcolor[2]))
         self._vtk_renderer.SetBackground2(qcolor)
         layout.addWidget(self._color_2_btn)
 
@@ -96,7 +96,7 @@ class RootProps(PropsBase):
         self._vtk_renderer.SetBackground2(clr)
 
     def onGradientBkgndChanged(self, state):
-        if state == QtCore.Qt.Checked:
+        if state == Qt.Checked:
             self._vtk_renderer.SetGradientBackground(True)
             self._color_2_btn.setEnabled(True)
         else:

--- a/otter/plugins/viz/TextProps.py
+++ b/otter/plugins/viz/TextProps.py
@@ -1,5 +1,5 @@
 import vtk
-from PyQt5 import QtWidgets
+from PyQt5.QtWidgets import QLineEdit, QHBoxLayout, QLabel
 from otter.plugins.viz.PropsBase import PropsBase
 from otter.plugins.viz.FontPropertiesWidget import FontPropertiesWidget
 from otter.plugins.common.ColorPicker import ColorPicker
@@ -20,7 +20,7 @@ class TextProps(PropsBase):
         return self._actor
 
     def setupWidgets(self):
-        self._text = QtWidgets.QLineEdit("Text")
+        self._text = QLineEdit("Text")
         self._layout.addWidget(self._text)
 
         self._font_props = FontPropertiesWidget(self)
@@ -28,10 +28,10 @@ class TextProps(PropsBase):
 
         self._color_picker = ColorPicker(self)
 
-        layout = QtWidgets.QHBoxLayout()
+        layout = QHBoxLayout()
         layout.setContentsMargins(0, 0, 0, 0)
 
-        lbl = QtWidgets.QLabel("Text color")
+        lbl = QLabel("Text color")
         layout.addWidget(lbl)
 
         self._color_btn = ColorButton()

--- a/otter/plugins/viz/ToolBar.py
+++ b/otter/plugins/viz/ToolBar.py
@@ -1,0 +1,67 @@
+from PyQt5.QtWidgets import QWidget, QHBoxLayout, QGraphicsOpacityEffect, \
+    QPushButton
+from PyQt5.QtCore import Qt
+
+
+class ToolBar(QWidget):
+    """
+    Window for entering parameters
+    """
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self._main_wnd = parent
+
+        self.setAttribute(Qt.WA_StyledBackground, True)
+        self.setObjectName("options")
+        self.setStyleSheet("""
+            #options, #closeButton {
+                border-radius: 6px;
+                background-color: rgb(0, 0, 0);
+                color: #fff;
+            }
+            QToolBar {
+                background-color: rgb(0, 0, 0);
+                color: #fff;
+            }
+            """)
+
+        self.setupWidgets()
+
+        effect = QGraphicsOpacityEffect()
+        effect.setOpacity(0.66)
+        self.setGraphicsEffect(effect)
+
+        self.setMinimumWidth(220)
+        self.updateWidgets()
+        self.connectSignals()
+
+        self.setAcceptDrops(True)
+
+    def mainWnd(self):
+        return self._main_wnd
+
+    def setupWidgets(self):
+        self._layout = QHBoxLayout()
+        self._layout.setContentsMargins(6, 5, 12, 12)
+        self._layout.setSpacing(0)
+
+        self._open_file = self.addButton("O", self._main_wnd.onOpenFile)
+        self._layout.addSpacing(8)
+        self._add_text = self.addButton("T", self._main_wnd.onAddText)
+
+        self._layout.addStretch()
+
+        self.setLayout(self._layout)
+
+    def addButton(self, text, action):
+        button = QPushButton(text)
+        button.clicked.connect(action)
+        self._layout.addWidget(button)
+        return button
+
+    def connectSignals(self):
+        pass
+
+    def updateWidgets(self):
+        pass

--- a/otter/plugins/viz/VizPlugin.py
+++ b/otter/plugins/viz/VizPlugin.py
@@ -1,4 +1,4 @@
-from PyQt5 import QtCore
+from PyQt5.QtCore import QCoreApplication
 from otter.assets import Assets
 from otter.plugins.Plugin import Plugin
 from otter.plugins.common.LoadFileEvent import LoadFileEvent
@@ -35,4 +35,4 @@ class VizPlugin(Plugin):
 
     def loadFile(self, file_name):
         event = LoadFileEvent(file_name)
-        QtCore.QCoreApplication.postEvent(self._main_window, event)
+        QCoreApplication.postEvent(self._main_window, event)

--- a/otter/plugins/viz/VizPlugin.py
+++ b/otter/plugins/viz/VizPlugin.py
@@ -2,7 +2,7 @@ from PyQt5 import QtCore
 from otter.assets import Assets
 from otter.plugins.Plugin import Plugin
 from otter.plugins.common.LoadFileEvent import LoadFileEvent
-from otter.plugins.viz.RenderWindow import RenderWindow
+from otter.plugins.viz.MainWindow import MainWindow
 
 
 class VizPlugin(Plugin):
@@ -12,7 +12,7 @@ class VizPlugin(Plugin):
 
     def __init__(self, parent):
         super().__init__(parent)
-        self._render_window = None
+        self._main_window = None
 
     @staticmethod
     def name():
@@ -23,16 +23,16 @@ class VizPlugin(Plugin):
         return Assets().icons['movie']
 
     def onCreate(self):
-        self._render_window = RenderWindow(self)
-        self.registerWindow(self._render_window)
+        self._main_window = MainWindow(self)
+        self.registerWindow(self._main_window)
 
         if self.parent is not None and hasattr(self.parent, 'window_menu'):
-            if hasattr(self._render_window, 'menuBar'):
-                self._render_window.menuBar().addMenu(self.parent.window_menu)
+            if hasattr(self._main_window, 'menuBar'):
+                self._main_window.menuBar().addMenu(self.parent.window_menu)
 
     def onClose(self):
-        self._render_window.close()
+        self._main_window.close()
 
     def loadFile(self, file_name):
         event = LoadFileEvent(file_name)
-        QtCore.QCoreApplication.postEvent(self._render_window, event)
+        QtCore.QCoreApplication.postEvent(self._main_window, event)

--- a/tests/plugins/viz/test_main_window.py
+++ b/tests/plugins/viz/test_main_window.py
@@ -1,12 +1,12 @@
 import pytest
 from unittest.mock import MagicMock, patch
 from PyQt5 import QtWidgets, QtCore
-from otter.plugins.viz.RenderWindow import RenderWindow
+from otter.plugins.viz.MainWindow import MainWindow
 
 
 @pytest.fixture
 def render_window(qtbot, viz_plugin):
-    wnd = RenderWindow(viz_plugin)
+    wnd = MainWindow(viz_plugin)
     qtbot.addWidget(wnd)
     yield wnd
 

--- a/tests/plugins/viz/test_plugin.py
+++ b/tests/plugins/viz/test_plugin.py
@@ -4,7 +4,7 @@ from otter.plugins.viz.VizPlugin import VizPlugin
 
 
 def test_init(viz_plugin):
-    assert viz_plugin._render_window is None
+    assert viz_plugin._main_window is None
 
 
 def test_name():


### PR DESCRIPTION
- RenderWindow -> MainWindow
- Removing splitter from the main window
- Redoing imports in ParamWindow
- Redoing imports in FileProps
- Redoing imports in FontPropertiesWidget
- Redoing imports in PropsBase
- Redoing imports in RootProps
- Redoing imports in TextProps
- Redoing imports in VizPlugin
- Viz: ParamWindow is a 'floating' widget
- Removing splitter form ParamsWindow
- Viz: show/hide objects window
- Viz: reset camera after loading a file
- Viz: set proper interactor style based on the dimensionality
- RootProps -> Background properties
- Viz: redoing imports in MainWindow
- Viz: remove all actors when clearing the scene
- Viz: 'floating' toolbar
- Viz: delete via context menu
